### PR TITLE
docker suggestions - as promised

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.idea
+.gitignore
+docker-compose.yml
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM node:18
 ##
 # FIX to have node_modules available correctly
 # Create and define the node_modules's cache directory.
-WORKDIR /cache
+#WORKDIR /cache
 
 # Then we copy package.josn and package-lock.json
-COPY package.json .
-COPY package-lock.json .
+COPY package*.json .
+#COPY package-lock.json .
 
 #Install node modules (add --silent to suppress output)
 RUN npm install
@@ -23,7 +23,7 @@ WORKDIR /app
 
 # We set the node environment variable.
 # add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
+#ENV PATH /app/node_modules/.bin:$PATH
 
 # copy source code
 # Finally, Copy everything from the current working directory of the host machine to the working directory inside the container ( which is app in this case ). This step is not necessary for the development Dockerfile though. We will map the host working directory to the containers working directory in the docker-compose.yml file anyway. But I like to keep this line here because in the future we may use this Dockerfile for production or take this Dockerfile as an inspiration to create the production Dockerfile. In that case, this line will work as a reminder that we need to copy the source code into the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,26 +3,27 @@ services: # each service below starts another container
   web: # web app
     build:
       context: . # we set the build context to the current folder .of the host machine
-      dockerfile: ./.docker/dev/Dockerfile # we provide the Dockerfile location which we want to use for building this (web) service.
-    restart: unless-stopped
-    # Also In our particular case, we are mapping everything inside the current context . to the app folder inside the container. If we do not map back node_modules from the container to the host then the host’s file will replace everything inside the containr's app folder. In this way, our node_modules folder generated earlier in the app folder inside the container will also get removed because we do not have any node module folder in our host machine. So we must map backnode_modules from the container to the host. Otherwise, our volume mapping.:/app will remove node_modules folder inside the container. Hence our setup will not work.
-    volumes:
-      - ".:/app" # The volume maps everything in the host machine to the app folder inside the container.
-      - "/app/node_modules" # Here we map node_modules folder inside the container to the host machine. Remember we did npm install in the app folder inside the docker container. So we have a node_modules inside the docker container which we can map back to the host machine.
+#      dockerfile: ./.docker/dev/Dockerfile # we provide the Dockerfile location which we want to use for building this (web) service.
+#    restart: unless-stopped
+    # Also In our particular case, we are mapping everything inside the current context . to the app folder inside the container. If we do not map back node_modules from the container to the host then the host’s file will replace everything inside the container's app folder. In this way, our node_modules folder generated earlier in the app folder inside the container will also get removed because we do not have any node module folder in our host machine. So we must map back node_modules from the container to the host. Otherwise, our volume mapping.:/app will remove node_modules folder inside the container. Hence our setup will not work.
+#    volumes:
+#      - ".:/app" # The volume maps everything in the host machine to the app folder inside the container.
+#      - "/app/node_modules" # Here we map node_modules folder inside the container to the host machine. Remember we did npm install in the app folder inside the docker container. So we have a node_modules inside the docker container which we can map back to the host machine.
     ports:
-      - 3000:3000 # we map the port so that we can access our react app running on port 3000 inside the container from outside i.e host machine.
+      - "3000:3000" # we map the port so that we can access our react app running on port 3000 inside the container from outside i.e host machine.
 
     # with the cp -rfu /cache/node_modules/. /app/node_modules/ command, we copy node_modules from the temporary cache directory to the working directory after the image is built. The -u flag is important because we want to copy files only if anything is changed in the node_modules folder. In this way, we won’t copy files every time we run docker-compose up to start our development.
-    # copy Deckerfile installed node_modules from cache folder to working folder
-    command: >
-      bash -c "cp -rfu /cache/node_modules/. /app/node_modules/
-      && npm start"
+    # copy Dockerfile installed node_modules from cache folder to working folder
+#    command: >
+#      bash -c "cp -rfu /cache/node_modules/. /app/node_modules/
+#      && npm start"
+    command: npm start
   # sample test container just for running the tests
-  test: # test suit for the react app.  Different container for running our tests. 
-    build:
-      context: .
-      dockerfile: ./.docker/dev/Dockerfile
-    volumes:
-      - .:/app
-      - /app/node_modules
-    command: ["npm", "test"]
+#  test: # test suit for the react app.  Different container for running our tests.
+#    build:
+#      context: .
+#      dockerfile: ./.docker/dev/Dockerfile
+#    volumes:
+#      - .:/app
+#      - /app/node_modules
+#    command: ["npm", "test"]


### PR DESCRIPTION
Added .dockerignore

docker-compose.yml:
restart: I am for fail fast
Moved the Dockerfile to the root
Disabled the volumes for prod, but re-enable if dev ports value should be in double quotes
The test has no place in a separate container. It should be done in CI: Build the image, Test the code inside image in a separate temporary container, upload the image to a registry (hub.docker, or AWS ECR). Then CD: Deploy the image from the registry into a container in the prod env.

In Dockerfile the steps should be: copy package json, npm i, workdir, then copy the source files.